### PR TITLE
Add missing flowy dependency and npm install to Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,11 @@
 # Dict.cc client for Goldendict
 
+## Installation
+After cloning, run the following in the repository root directory:
+```shell
+npm install
+```
+
 ## Usage
 
 In the Goldendict "Dictionaries" settings, in "Programs" section, add an entry

--- a/index.js
+++ b/index.js
@@ -30,5 +30,6 @@ function urlForTerm(term) {
 function stripBody(html) {
   var $ = cheerio.load(html);
   var results = $.html('body > div > dl')
-  return results && `<div class="dictcc">${results}</div>`
+  var absUrlsResults = results.toString().replace(/href=\"\/\?/g, 'href=\"http://pocket.dict.cc/?')
+  return absUrlsResults && `<div class="dictcc">${absUrlsResults}</div>`
 }

--- a/index.js
+++ b/index.js
@@ -24,7 +24,7 @@ function urlForTerm(term) {
     };
 
     var lang = term.match(/[а-яА-Я]/) ? 'deru' : 'deen';
-    return langs[lang] + '?s=' + term;
+    return langs[lang] + '?s=' + encodeURIComponent(term);
 }
 
 function stripBody(html) {

--- a/package.json
+++ b/package.json
@@ -3,8 +3,7 @@
   "version": "1.0.0",
   "description": "An unofficial client to dict.cc online dictionary",
   "main": "index.js",
-  "scripts": {
-  },
+  "scripts": {},
   "keywords": [
     "dict.cc",
     "dictionary",
@@ -15,6 +14,7 @@
   "license": "MIT",
   "dependencies": {
     "cheerio": "^0.17.0",
+    "flowy": "^0.4.0",
     "request": "^2.36.0"
   }
 }


### PR DESCRIPTION
Hi Alexey, thanks for sharing this goldendict utility - I've made two small fixes for the missing dependency and a mention of `npm install` to the Readme.
Many thanks, Andrew